### PR TITLE
Fixes `@item.level` for `.use` and `.rollDamage`.

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,7 +1,7 @@
 {
   "id": "babonus",
   "title": "Build-a-Bonus",
-  "version": "10.2.2",
+  "version": "10.2.3",
   "authors": [
     {
       "name": "Zhell",
@@ -47,7 +47,7 @@
   "url": "https://github.com/krbz999/babonus",
   "license": "https://raw.githubusercontent.com/krbz999/babonus/main/LICENSE",
   "manifest": "https://github.com/krbz999/babonus/releases/latest/download/module.json",
-  "download": "https://github.com/krbz999/babonus/releases/download/v10.2.2/module.zip",
+  "download": "https://github.com/krbz999/babonus/releases/download/v10.2.3/module.zip",
   "description": "Make it easier to manage very particular and niche bonuses and auras, on actors, items, effects, and templates.",
   "name": "babonus",
   "minimumCoreVersion": "10"

--- a/scripts/helpers/helpers.mjs
+++ b/scripts/helpers/helpers.mjs
@@ -204,7 +204,12 @@ export function _getActorItemBonuses(actor, hookType, { item } = {}) {
       if (attunement !== ATTUNED && needsAtt) return false;
       return true;
     });
-    boni.push(..._replaceRollData(ai, bonuses));
+    /**
+     * Do not replace roll data for the item itself, as this will remove upcasting.
+     * This data is handled by the system itself.
+     */
+    if(item?.id === ai.id) boni.push(...bonuses);
+    else boni.push(..._replaceRollData(ai, bonuses));
   }
   return boni;
 }


### PR DESCRIPTION
When upcasting a spell and finding and applying bonuses, the upcast item's spell level is not taken into account for purposes of `@item.level`. Since this is only relevant when the roll is originating from that item, simply *not* replacing its roll data and leaving it for the system to do is sufficient.

This fixes the issue for `dnd5e.preUseItem` and `dnd5e.preRollDamage`, but does not fix it for `dnd5e.preRollAttack`, since the upcast spell level is never passed along here.