### PR TITLE
Better compatibility with Window Tabs module

### DIFF
--- a/scripts/helpers/headerButtons.mjs
+++ b/scripts/helpers/headerButtons.mjs
@@ -37,7 +37,7 @@ class InjectHeaderButton {
       icon: MODULE.ICON,
       onclick: () => new BabonusWorkshop(app.document).render(true)
     };
-    if (this.showLabel) button.label = this.label;
+    button.label = this.showLabel ? this.label : '';
     array.unshift(button);
   }
 }
@@ -70,7 +70,7 @@ class InjectHeaderButtonDialog extends InjectHeaderButton {
       icon: MODULE.ICON,
       onclick: () => new AppliedBonusesDialog({bonuses, dialog: app}).render(true)
     };
-    if (this.showLabel) button.label = this.label;
+    button.label = this.showLabel ? this.label : '';
     array.unshift(button);
   }
 }


### PR DESCRIPTION
Add a button title of `''` when the `showLabel` setting is false for compatibility with Window Tabs module.

![image](https://github.com/krbz999/babonus/assets/7237090/bf514199-3645-4c19-bf75-a316e6c0dd6e)

![image](https://github.com/krbz999/babonus/assets/7237090/76374788-9a1f-4719-99d2-92de43ee916c)


